### PR TITLE
#27 - 헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/java/than/myboard/controller/ArticleController.java
+++ b/src/main/java/than/myboard/controller/ArticleController.java
@@ -79,7 +79,7 @@ public class ArticleController {
     @PostMapping("/form")
     public String postNewArticle(ArticleRequest articleRequest) {
         articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-                "than", "q1w2e3r4", "than@gmail.com", "Than", "memo", null, null, null,  null
+                "than", "q1w2e3r4", "than@gmail.com", "Than", "memo"
         )));
 
         return "redirect:/articles";
@@ -98,7 +98,7 @@ public class ArticleController {
     @PostMapping("/{articleId}/form")
     public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
         articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of(
-                "than", "q1w2e3r4", "than@gmail.com", "Than", "memo", null, null, null,  null
+                "than", "q1w2e3r4", "than@gmail.com", "Than", "memo"
         )));
 
         return "redirect:/articles/" + articleId;

--- a/src/main/java/than/myboard/dto/UserAccountDto.java
+++ b/src/main/java/than/myboard/dto/UserAccountDto.java
@@ -15,6 +15,11 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccountDto(userId, userPassword, email, nickname, memo, null, null, null, null);
+    }
+
     public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new UserAccountDto(userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/main/java/than/myboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/than/myboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -18,7 +18,7 @@ public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport imple
         return from(article)
                 .distinct()
                 .select(article.hashtag)
-                .where(article.hashtag.isNotEmpty())
+                .where(article.hashtag.isNotNull())
                 .fetch();
     }
 }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -10,7 +10,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
 헤더에 해시태그 메뉴를 추가하여 쉽게 해시태그 검색 페이지 존재를 알고, 들어갈 수 있게 한다.

This closes #27 